### PR TITLE
让filters可以固定在插件市场顶部

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -2,9 +2,15 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
-    padding-right: 7px;
     margin-top: 10px;
     margin-bottom: 15px;
+    position: sticky;
+    top: -10px;
+    z-index: 100;
+    background: rgba(var(--contrast-rgb), 0.04);
+    border-radius: 8px;
+    padding: 5px 6px 5px 15px;
+    backdrop-filter: blur(10px);
 
     .plugin-market-filter-category {
         min-width: 250px;
@@ -26,7 +32,7 @@
                 position: absolute;
                 left: 50%;
                 right: 50%;
-                bottom: -10px;
+                bottom: -9px;
                 background: #ec4141;
                 height: 4px;
                 border-radius: 10px;
@@ -867,6 +873,7 @@ body.plugins-have-update {
     background: rgba(var(--contrast-rgb), 0.04);
     border-radius: 8px;
     padding: 10px 15px;
+    backdrop-filter: blur(10px);
 
     .plugin-market-settings-header {
         font-size: 18px;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -7,7 +7,7 @@
     position: sticky;
     top: -10px;
     z-index: 100;
-    background: rgba(var(--contrast-rgb), 0.04);
+    background: var(--container-bg);
     border-radius: 8px;
     padding: 5px 6px 5px 15px;
     backdrop-filter: blur(10px);
@@ -868,7 +868,7 @@ body.plugins-have-update {
 }
 
 .plugin-market-settings {
-    background: rgba(var(--contrast-rgb), 0.04);
+    background: var(--container-bg);
     border-radius: 8px;
     padding: 10px 15px;
     backdrop-filter: blur(10px);
@@ -1081,6 +1081,7 @@ body.ncm-light-theme {
     .plugin-market-root {
         --contrast: #000;
         --contrast-rgb: 0, 0, 0;
+        --container-bg: #EEEA;
     }
 
     .plugin-market-filters .plugin-market-filter-sort>button {
@@ -1125,5 +1126,6 @@ body:not(.ncm-light-theme) {
     .plugin-market-root {
         --contrast: #fff;
         --contrast-rgb: 255, 255, 255;
+        --container-bg: #4446;
     }
 }

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -72,11 +72,9 @@
                 width: 16px;
                 height: 16px;
                 opacity: .5;
-                transform: translate(2px, 1px);
-
+                transform: translateY(1px);
                 position: absolute;
-                right: -12px;
-                top: 32px;
+                right: -31px;
             }
         }
     }


### PR DESCRIPTION
让filters可以固定在插件市场顶部，并添加背景模糊（顺便设置也加了，统一外观）
![image](https://github.com/user-attachments/assets/fd87d5e5-70ba-4984-81c2-eefe65b251d0)
![image](https://github.com/user-attachments/assets/c53ffb3a-1b50-461b-af6b-9b6149dce01e)

（对比度不行…）
![image](https://github.com/user-attachments/assets/b63fa3d3-b181-4b15-82da-0de796c7bfc3)

（注：这张图里设置按钮歪了）
![image](https://github.com/user-attachments/assets/0efdc5d8-bcce-4f2f-97c4-68c6c6aeef8a)

已Fix: 修改后设置按钮错位
![image](https://github.com/user-attachments/assets/fb52f79c-b009-4a09-81cc-4e10e1a58561)